### PR TITLE
Fix options_set function.

### DIFF
--- a/src/stc8prog.c
+++ b/src/stc8prog.c
@@ -353,8 +353,8 @@ int option_set(const stc_protocol_t * stc_protocol, uint8_t *recv)
     options[27] = (uint8_t)((stc_params.trim_frequency) & 0xFF);
 
     /* fill trim value */
-    options[28] = (uint8_t)((stc_params.trim_calibration_id) & 0xFF); //calib id
-    options[29] = (uint8_t)((stc_params.trim_value) & 0xFF);
+    options[28] = (uint8_t)((stc_params.trim_value) & 0xFF);
+    options[29] = (uint8_t)((stc_params.trim_calibration_id) & 0xFF); //calib id
 
     /* fill divider */
     options[30] = (uint8_t)((stc_params.trim_divider) & 0xFF);


### PR DESCRIPTION
Customer found an issue with actual MCU frequency, however trimming value was correct in options.
Fixed sequence in options to set right trim value.
